### PR TITLE
Rename motors to use color names

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -9,30 +9,34 @@ import kotlin.math.*
  */
 object TriWheels : API() {
     // All 3 wheels on the robot
-    private lateinit var wheel1: DcMotor
-    private lateinit var wheel2: DcMotor
-    private lateinit var wheel3: DcMotor
+    lateinit var red: DcMotor
+        private set
+    lateinit var green: DcMotor
+        private set
+    lateinit var blue: DcMotor
+        private set
 
     // The angles of each wheel
-    const val MOTOR_1_ANGLE: Double = 0.0
-    const val MOTOR_2_ANGLE: Double = PI * (2.0 / 3.0)
-    const val MOTOR_3_ANGLE: Double = 2.0 * MOTOR_2_ANGLE
+    const val RED_ANGLE: Double = 0.0
+    // TODO: Check that these two angles aren't swapped
+    const val GREEN_ANGLE: Double = PI * (2.0 / 3.0)
+    const val BLUE_ANGLE: Double = 2.0 * GREEN_ANGLE
 
     override fun init(opMode: OpMode) {
         super.init(opMode)
 
-        this.wheel1 = hardwareMap.get(DcMotor::class.java, "wheel1")
-        this.wheel2 = hardwareMap.get(DcMotor::class.java, "wheel2")
-        this.wheel3 = hardwareMap.get(DcMotor::class.java, "wheel3")
+        this.red = hardwareMap.get(DcMotor::class.java, "redWheel")
+        this.green = hardwareMap.get(DcMotor::class.java, "greenWheel")
+        this.blue = hardwareMap.get(DcMotor::class.java, "blueWheel")
     }
 
     /**
      * Sets the power of each wheel respectively.
      */
-    fun power(power1: Double, power2: Double, power3: Double) {
-        this.wheel1.power = power1
-        this.wheel2.power = power2
-        this.wheel3.power = power3
+    fun power(redPower: Double, greenPower: Double, bluePower: Double) {
+        this.red.power = redPower
+        this.green.power = greenPower
+        this.blue.power = bluePower
     }
 
     /**
@@ -47,9 +51,9 @@ object TriWheels : API() {
      */
     fun moveDirection(radians: Double, magnitude: Double) {
         this.power(
-            magnitude * sin(this.MOTOR_1_ANGLE - radians),
-            magnitude * sin(this.MOTOR_2_ANGLE - radians),
-            magnitude * sin(this.MOTOR_3_ANGLE - radians),
+            magnitude * sin(this.RED_ANGLE - radians),
+            magnitude * sin(this.GREEN_ANGLE - radians),
+            magnitude * sin(this.BLUE_ANGLE - radians),
         )
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/TeleOpMovement.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/TeleOpMovement.kt
@@ -39,9 +39,9 @@ object TeleOpMovement : Component {
 
         // all movement of the wheels
         TriWheels.power(
-            joyMagnitude * sin(TriWheels.MOTOR_1_ANGLE - joyRadians) + rotationPower,
-            joyMagnitude * sin(TriWheels.MOTOR_2_ANGLE - joyRadians) + rotationPower,
-            joyMagnitude * sin(TriWheels.MOTOR_3_ANGLE - joyRadians) + rotationPower,
+            joyMagnitude * sin(TriWheels.RED_ANGLE - joyRadians) + rotationPower,
+            joyMagnitude * sin(TriWheels.GREEN_ANGLE - joyRadians) + rotationPower,
+            joyMagnitude * sin(TriWheels.BLUE_ANGLE - joyRadians) + rotationPower,
         )
     }
 }


### PR DESCRIPTION
This renames the motors in `TriWheels` to match the color-based naming scheme. It is a breaking change, but shouldn't affect too much else.