### PR TITLE
Set correct angles for wheels

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -18,9 +18,9 @@ object TriWheels : API() {
         private set
 
     // The angles of each wheel
-    const val RED_ANGLE: Double = 0.0
-    const val GREEN_ANGLE: Double = PI * (4.0 / 3.0)
-    const val BLUE_ANGLE: Double = PI * (2.0 / 3.0)
+    const val RED_ANGLE: Double = PI / 2.0
+    const val GREEN_ANGLE: Double = PI * (11.0 / 6.0)
+    const val BLUE_ANGLE: Double = PI * (7.0 / 6.0)
 
     override fun init(opMode: OpMode) {
         super.init(opMode)


### PR DESCRIPTION
Originally, we set the red wheel (front) to 0 radians. This is incorrect, since 0 radians is on the right and not the front. (See figure.) Last year, we even [manually corrected this value](https://github.com/BotsBurgh/BOTSBURGH-FTC-2022-23/blob/3bee96584f17680599847ec9985700a4d46a790e/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/components/WheelsTeleOp.kt#L43-L44).

This PR changes the wheel angles themselves to say the front is `PI / 2.0`, with the other wheels 120 degrees apart. It will need testing, but it will fix some confusion on where the front of the robot actually is.

[![Unit circle angles](https://upload.wikimedia.org/wikipedia/commons/4/4c/Unit_circle_angles_color.svg)](https://commons.wikimedia.org/wiki/File:Unit_circle_angles_color.svg#/media/File:Unit_circle_angles_color.svg)