### PR TITLE
Autonomous Scaffolding

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/API.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/API.kt
@@ -4,9 +4,12 @@ import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import com.qualcomm.robotcore.hardware.HardwareMap
 
 /**
- * An API is a shared class used between multiple components.
+ * An API is shared code used by components.
  *
- * An API needs to be initialized with the [init] function before it can be used.
+ * An API needs to be initialized with the [init] function before it can be used. In general, APIs
+ * should not have side-effects unless told to by a component.
+ *
+ * If an API depends on another API, it should say so in the object documentation.
  */
 abstract class API {
     private var uninitializedOpMode: OpMode? = null

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/DemoQuadWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/DemoQuadWheels.kt
@@ -3,20 +3,20 @@ package org.firstinspires.ftc.teamcode.api
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import com.qualcomm.robotcore.hardware.DcMotor
 
-// APIs are shared code used by components.
-// As compared to components, which can be disabled, APIs usually aren't.
-// As such, using them should have no side-effects. (An API shouldn't make the robot move unless
-// told to by a component.)
-// This API is used to control a four-wheeled robot.
+/**
+ * This is a demo API used for controlling a robot with four mecanum wheels.
+ */
 object DemoQuadWheels : API() {
     // The wheel motors
+    // `lateinit` means the variable does not have to be initialized in the constructor
+    // See: https://github.com/BotsBurgh/BOTSBURGH-FTC-2023-24/pull/7#discussion_r1342154226
     private lateinit var fl: DcMotor
     private lateinit var fr: DcMotor
     private lateinit var bl: DcMotor
     private lateinit var br: DcMotor
 
     // This is how you define FTC Dashboard configuration.
-    // Uncomment the following line to enable it.
+    // Uncomment the following line to enable it:
     // @Config
     private object DemoQuadWheelsConfig {
         @JvmField
@@ -26,6 +26,8 @@ object DemoQuadWheels : API() {
         var SOME_NAME = "Bob"
     }
 
+    // `init()` is run once at the beginning of the program.
+    // It initializes things and sets up configuration
     override fun init(opMode: OpMode) {
         // You must call super.init(opMode), or the API will not initialize correctly.
         super.init(opMode)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/Component.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/Component.kt
@@ -3,7 +3,7 @@ package org.firstinspires.ftc.teamcode.components
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 
 /**
- * A component is a class that makes the robot do something.
+ * A component is a class that makes the robot do something during teleop.
  *
  * Components provoke visible change from the robot, like moving the wheels or arms. To share code
  * between components, see the API folder.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/Component.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/Component.kt
@@ -7,6 +7,8 @@ import com.qualcomm.robotcore.eventloop.opmode.OpMode
  *
  * Components provoke visible change from the robot, like moving the wheels or arms. To share code
  * between components, see the API folder.
+ *
+ * If a component depends on another API, it should say so in the object documentation.
  */
 interface Component {
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/DemoForward.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/DemoForward.kt
@@ -3,9 +3,11 @@ package org.firstinspires.ftc.teamcode.components
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import org.firstinspires.ftc.teamcode.api.DemoQuadWheels
 
-// Components are pieces of code that make the robot do something.
-// This one makes the robot go forward when A is pressed.
-// Note how it is an object and inherits `Component`.
+/**
+ * A component that makes the robot go forward when A is pressed.
+ *
+ * It requires the [DemoQuadWheels] API.
+ */
 object DemoForward : Component {
     override fun loop(opMode: OpMode) {
         if (opMode.gamepad1.a) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/linear/DemoSpinLinear.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/linear/DemoSpinLinear.kt
@@ -1,0 +1,19 @@
+package org.firstinspires.ftc.teamcode.components.linear
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
+import org.firstinspires.ftc.teamcode.api.DemoQuadWheels
+
+/**
+ * A demo linear component that spins the robot for 2 seconds, then stops.
+ *
+ * It requires the [DemoQuadWheels] API.
+ */
+object DemoSpinLinear : LinearComponent {
+    override fun run(opMode: LinearOpMode) {
+        DemoQuadWheels.drive(1.0, -1.0, 1.0, -1.0)
+
+        opMode.sleep(2 * 1000)
+
+        DemoQuadWheels.drive(0.0)
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/linear/LinearComponent.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/linear/LinearComponent.kt
@@ -1,0 +1,19 @@
+package org.firstinspires.ftc.teamcode.components.linear
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
+
+/**
+ * A linear component is a class that makes the robot do something during autonomous.
+ *
+ * Unlike normal components, linear components are meant to be run during the autonomous phase. They
+ * are run in sequence, and thus use a [LinearOpMode] instead of a normal OpMode.
+ */
+interface LinearComponent {
+    /**
+     * Runs the linear component.
+     *
+     * This function will be run once. Unless programmed otherwise, this component will have
+     * complete control of the robot when [run] is called.
+     */
+    fun run(opMode: LinearOpMode)
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/DemoAutonomous.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/DemoAutonomous.kt
@@ -1,0 +1,22 @@
+package org.firstinspires.ftc.teamcode.opmode.autonomous
+
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous
+import com.qualcomm.robotcore.eventloop.opmode.Disabled
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
+import org.firstinspires.ftc.teamcode.api.DemoQuadWheels
+import org.firstinspires.ftc.teamcode.components.linear.DemoSpinLinear
+
+@Autonomous(name = "Demo Autonomous")
+@Disabled
+class DemoAutonomous : LinearOpMode() {
+    override fun runOpMode() {
+        // APIs are initialized here
+        DemoQuadWheels.init(this)
+
+        // Wait for the run button to be pressed
+        waitForStart()
+
+        // Linear components are run in order
+        DemoSpinLinear.run(this)
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/DemoTeleOp.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/DemoTeleOp.kt
@@ -8,7 +8,7 @@ import org.firstinspires.ftc.teamcode.api.vision.AprilVision
 import org.firstinspires.ftc.teamcode.api.vision.Vision
 import org.firstinspires.ftc.teamcode.components.DemoForward
 
-@TeleOp(name = "Demo")
+@TeleOp(name = "Demo TeleOp")
 @Disabled
 class DemoTeleOp : OpMode() {
     // Run once, when "Init" is pressed on driver hub.


### PR DESCRIPTION
This PR creates the special `LinearComponent` interface for use specifically in autonomous. It also specifies that the normal `Component` should only be used in teleop. I also updated the documentation for various files to clear up misconceptions.