### PR TITLE
Fix teleop driving angle

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/TeleOpMovement.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/TeleOpMovement.kt
@@ -47,6 +47,7 @@ object TeleOpMovement : Component {
         val joyY = gamepad.left_stick_y.toDouble()
 
         // angle and strength
+        // PI / 3 because 0 radians is right, not forward
         val joyRadians = atan2(joyY, joyX) - (PI / 3.0)
         val joyMagnitude = sqrt(joyY * joyY + joyX * joyX)
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/TeleOpMovement.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/TeleOpMovement.kt
@@ -47,7 +47,7 @@ object TeleOpMovement : Component {
         val joyY = gamepad.left_stick_y.toDouble()
 
         // angle and strength
-        val joyRadians = atan2(joyY, joyX) - (PI / 3.0) - (PI / 2.0)
+        val joyRadians = atan2(joyY, joyX) - (PI / 3.0)
         val joyMagnitude = sqrt(joyY * joyY + joyX * joyX)
 
         // all movement of the wheels

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/TeleOpMovement.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/TeleOpMovement.kt
@@ -15,7 +15,6 @@ import kotlin.math.sqrt
  */
 object TeleOpMovement : Component {
     private const val ROTATION_GAIN = 0.6
-    private const val SLOW_TURN_AMOUNT = 0.3
 
     override fun loop(opMode: OpMode) {
         // This prevents the normal movement from running when the robot is target-locking an april
@@ -30,17 +29,9 @@ object TeleOpMovement : Component {
      * The movement functionality run by default when [TeleOpState] is default.
      */
     private fun default_loop(opMode: OpMode) {
-        // renaming gamepad1
+        // alias gamepad1
         val gamepad = opMode.gamepad1
-        var rotationPower = ROTATION_GAIN * -gamepad.right_stick_x.toDouble()
-
-        // right bumper and left bumper movement
-        // will slowly turn the robot
-        if (gamepad.left_bumper) {
-            rotationPower += SLOW_TURN_AMOUNT
-        } else if (gamepad.right_bumper) {
-            rotationPower -= SLOW_TURN_AMOUNT
-        }
+        val rotationPower = ROTATION_GAIN * -gamepad.right_stick_x.toDouble()
 
         // joystick input
         val joyX = gamepad.left_stick_x.toDouble()


### PR DESCRIPTION
This should fix the forward direction being rotated oddly. It also has a few other changes related to teleop. This will cause merge conflicts with the `axisLock` branch, so it might be worth waiting and moving the changes to `axisLock`.