### PR TITLE
Resettable APIs and Components

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/API.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/API.kt
@@ -2,6 +2,7 @@ package org.firstinspires.ftc.teamcode.api
 
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import com.qualcomm.robotcore.hardware.HardwareMap
+import org.firstinspires.ftc.teamcode.utils.Resettable
 
 /**
  * An API is shared code used by components.
@@ -12,7 +13,7 @@ import com.qualcomm.robotcore.hardware.HardwareMap
  * If an API depends on another API, it should say so in the object documentation.
  */
 abstract class API {
-    private var uninitializedOpMode: OpMode? = null
+    private var uninitializedOpMode: OpMode? by Resettable { null }
 
     protected val opMode: OpMode
         get() = uninitializedOpMode

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/GamepadEx.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/GamepadEx.kt
@@ -5,6 +5,7 @@ import org.firstinspires.ftc.teamcode.api.GamepadEx.justPressed
 import org.firstinspires.ftc.teamcode.api.GamepadEx.justReleased
 import org.firstinspires.ftc.teamcode.api.GamepadEx.pressed
 import org.firstinspires.ftc.teamcode.api.GamepadEx.update
+import org.firstinspires.ftc.teamcode.utils.Resettable
 
 /**
  * A [Gamepad] extension for more complex inputs.
@@ -40,9 +41,9 @@ object GamepadEx : API() {
     private val gamepad: Gamepad
         get() = this.opMode.gamepad1
 
-    private val pressed = mutableSetOf<Inputs>()
-    private val justPressed = mutableSetOf<Inputs>()
-    private val justReleased = mutableSetOf<Inputs>()
+    private val pressed: MutableSet<Inputs> by Resettable { mutableSetOf() }
+    private val justPressed: MutableSet<Inputs> by Resettable { mutableSetOf() }
+    private val justReleased: MutableSet<Inputs> by Resettable { mutableSetOf() }
 
     /** Returns true if input it pressed. */
     fun pressed(input: Inputs): Boolean = input in this.pressed

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TeleOpState.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TeleOpState.kt
@@ -1,5 +1,7 @@
 package org.firstinspires.ftc.teamcode.api
 
+import org.firstinspires.ftc.teamcode.utils.Resettable
+
 /**
  * A state machine for teleop used to configure behavior.
  *
@@ -16,5 +18,5 @@ object TeleOpState : API() {
      *
      * Be very careful about changing this value, as it affects many other things.
      */
-    var state = State.Default
+    var state: State by Resettable { State.Default }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/DPadCommands.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/DPadCommands.kt
@@ -3,6 +3,7 @@ package org.firstinspires.ftc.teamcode.components
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import org.firstinspires.ftc.teamcode.api.GamepadEx
 import org.firstinspires.ftc.teamcode.api.TeleOpState
+import org.firstinspires.ftc.teamcode.utils.Resettable
 
 /**
  * A component that changes the state of the robot based on DPad inputs.
@@ -21,7 +22,7 @@ object DPadCommands : Component {
     private enum class CommandGroup
 
     /** The current selected command group. */
-    private var selected_group: CommandGroup? = null
+    private var selected_group: CommandGroup? by Resettable { null }
 
     override fun loop(opMode: OpMode) {
         GamepadEx.update()

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/DemoAutonomous.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/DemoAutonomous.kt
@@ -6,11 +6,15 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import org.firstinspires.ftc.teamcode.api.DemoQuadWheels
 import org.firstinspires.ftc.teamcode.components.Telemetry
 import org.firstinspires.ftc.teamcode.components.linear.DemoSpinLinear
+import org.firstinspires.ftc.teamcode.utils.Reset
 
 @Autonomous(name = "Demo Autonomous")
 @Disabled
 class DemoAutonomous : LinearOpMode() {
     override fun runOpMode() {
+        // Reset is a special utility necessary in all opmodes.
+        Reset.init(this)
+
         // APIs are initialized here
         DemoQuadWheels.init(this)
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/DemoTeleOp.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/DemoTeleOp.kt
@@ -8,12 +8,16 @@ import org.firstinspires.ftc.teamcode.api.vision.AprilVision
 import org.firstinspires.ftc.teamcode.api.vision.Vision
 import org.firstinspires.ftc.teamcode.components.DemoForward
 import org.firstinspires.ftc.teamcode.components.Telemetry
+import org.firstinspires.ftc.teamcode.utils.Reset
 
 @TeleOp(name = "Demo TeleOp")
 @Disabled
 class DemoTeleOp : OpMode() {
     // Run once, when "Init" is pressed on driver hub.
     override fun init() {
+        // Reset is a special utility necessary in all opmodes.
+        Reset.init(this)
+
         // Initializes an API, shared code used by components.
         DemoQuadWheels.init(this)
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.kt
@@ -8,12 +8,14 @@ import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.components.DPadCommands
 import org.firstinspires.ftc.teamcode.components.TeleOpMovement
 import org.firstinspires.ftc.teamcode.components.Telemetry
+import org.firstinspires.ftc.teamcode.utils.Reset
 
 @TeleOp(name = "TeleOpMain")
 class TeleOpMain : OpMode() {
     // init will run once
     override fun init() {
         // APIs (code that can be used in components)
+        Reset.init(this)
 
         // Triangle wheel controls
         TriWheels.init(this)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
@@ -26,7 +26,7 @@ object Reset {
     fun init(opMode: OpMode) {
         // Check that, if Reset has been called before, it is not called on the same opmode run by
         // ensuring the opmode references are different.
-        if (opModeReference != null && opModeReference == opMode) {
+        if (opModeReference == opMode) {
             throw IllegalStateException("Tried to initialize the Reset API more than once in a single run.")
         }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
@@ -1,0 +1,96 @@
+package org.firstinspires.ftc.teamcode.utils
+
+import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import kotlin.reflect.KProperty
+
+/**
+ * A set of functions that, when called, will reset the state of all APIs and components.
+ */
+private val resetFunctions = mutableSetOf<() -> Unit>()
+
+/**
+ * An object that resets the property states of the robot, used between opmode runs.
+ *
+ * **This must be initialized first, before any other code is run!**
+ *
+ * @see Resettable
+ */
+object Reset {
+    /**
+     * A reference to the last-initialized opmode, used purely to ensure that [Reset] is not called
+     * more than once per run.
+     */
+    private var opModeReference: OpMode? = null
+
+    /** Resets any registered [Resettable] properties. */
+    fun init(opMode: OpMode) {
+        // Check that, if Reset has been called before, it is not called on the same opmode run by
+        // ensuring the opmode references are different.
+        if (opModeReference != null && opModeReference == opMode) {
+            throw IllegalStateException("Tried to initialize the Reset API more than once in a single run.")
+        }
+
+        // Set new opmode reference.
+        opModeReference = opMode
+
+        // Reset any registered properties.
+        resetAll()
+    }
+
+    private fun resetAll() {
+        // Call each reset function
+        resetFunctions.forEach { it() }
+    }
+}
+
+/**
+ * A property delegate that instruments resetting it between opmode runs.
+ *
+ * This is used in [delegate properties](https://kotlinlang.org/docs/delegated-properties.html). You
+ * must pass a function when constructing the resettable property that returns its default value.
+ *
+ * ```
+ * val property: Type by Resettable {
+ *     // This is a function body.
+ *     // You can run anything in here.
+ *     val x = 1 + 2
+ *
+ *     // You do not need the `return` keyword.
+ *     // The last expression in the block, will be returned.
+ *     x + 2 // will return 5
+ * }
+ * ```
+ *
+ * # Example
+ *
+ * ```
+ * object MyAPI: API() {
+ *     // The starting value of someState is 10
+ *     private var someState: Int by Resettable { 10 }
+ * }
+ * ```
+ */
+class Resettable<T>(private val default: () -> T) {
+    /** The actual value of the resettable property. */
+    private var inner: T = this.default()
+
+    init {
+        // Add the reset function to a global set.
+        resetFunctions.add(this::reset)
+    }
+
+    // Simply return the inner value.
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        return this.inner
+    }
+
+    // Simply set the inner value.
+    operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        this.inner = value
+    }
+
+    /** A function that resets the value of [inner] to [default]'s return. */
+    private fun reset() {
+        this.inner = this.default()
+    }
+}


### PR DESCRIPTION
This PR implements the ability to reset code between opmode runs. `Reset.kt` is the file with the actual implementation. (63d8040314d5849b91fd77da8c05013df2b2747d) All the other changes are just updating code to add resetting.

- [x] `Reset` class
- [x] `Resettable` delegate properties
- [x] Initialize `Reset` at the beginning of all opmodes
- [x] Make most API and component properties resettable