### PR TITLE
TriWheels Changes

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -40,9 +40,9 @@ object TriWheels : API() {
     }
 
     /**
-     * Sets the power of all 3 wheels to the same value.
+     * Rotates the wheels with a given power.
      */
-    fun power(power: Double) {
+    fun rotate(power: Double) {
         this.power(power, power, power)
     }
 
@@ -63,6 +63,20 @@ object TriWheels : API() {
      * This is shorthand for setting the power to 0.
      */
     fun stop() {
-        this.power(0.0)
+        this.power(0.0, 0.0, 0.0)
+    }
+
+    /**
+     * Sets the power of all 3 wheels to the same value.
+     *
+     * @see rotate
+     */
+    @Deprecated(
+        message = "This function has been renamed.",
+        replaceWith = ReplaceWith("this.rotate(power)"),
+        level = DeprecationLevel.WARNING,
+    )
+    fun power(power: Double) {
+        this.rotate(power)
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -47,9 +47,9 @@ object TriWheels : API() {
     }
 
     /**
-     * Makes the robot move in a certain direction [radians] with a given strength [magnitude].
+     * Makes the robot drive in a certain direction [radians] with a given strength [magnitude].
      */
-    fun moveDirection(radians: Double, magnitude: Double) {
+    fun drive(radians: Double, magnitude: Double) {
         this.power(
             magnitude * sin(this.RED_ANGLE - radians),
             magnitude * sin(this.GREEN_ANGLE - radians),
@@ -66,11 +66,6 @@ object TriWheels : API() {
         this.power(0.0, 0.0, 0.0)
     }
 
-    /**
-     * Sets the power of all 3 wheels to the same value.
-     *
-     * @see rotate
-     */
     @Deprecated(
         message = "This function has been renamed.",
         replaceWith = ReplaceWith("this.rotate(power)"),
@@ -78,5 +73,14 @@ object TriWheels : API() {
     )
     fun power(power: Double) {
         this.rotate(power)
+    }
+
+    @Deprecated(
+        message = "This function has been renamed.",
+        replaceWith = ReplaceWith("this.drive(radians, magnitude)"),
+        level = DeprecationLevel.WARNING,
+    )
+    fun moveDirection(radians: Double, magnitude: Double) {
+        this.drive(radians, magnitude)
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -18,9 +18,9 @@ object TriWheels : API() {
         private set
 
     // The angles of each wheel
-    const val RED_ANGLE: Double = PI / 2.0
-    const val GREEN_ANGLE: Double = PI * (11.0 / 6.0)
-    const val BLUE_ANGLE: Double = PI * (7.0 / 6.0)
+    private const val RED_ANGLE: Double = PI / 2.0
+    private const val GREEN_ANGLE: Double = PI * (11.0 / 6.0)
+    private const val BLUE_ANGLE: Double = PI * (7.0 / 6.0)
 
     override fun init(opMode: OpMode) {
         super.init(opMode)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -50,10 +50,17 @@ object TriWheels : API() {
      * Makes the robot drive in a certain direction [radians] with a given strength [magnitude].
      */
     fun drive(radians: Double, magnitude: Double) {
+        this.driveWithRotation(radians, magnitude, 0.0)
+    }
+
+    /**
+     * Does the same thing as [drive] but it rotates the robot with a given [rotation] too.
+     */
+    fun driveWithRotation(radians: Double, magnitude: Double, rotation: Double) {
         this.power(
-            magnitude * sin(this.RED_ANGLE - radians),
-            magnitude * sin(this.GREEN_ANGLE - radians),
-            magnitude * sin(this.BLUE_ANGLE - radians),
+            magnitude * sin(this.RED_ANGLE - radians) + rotation,
+            magnitude * sin(this.GREEN_ANGLE - radians) + rotation,
+            magnitude * sin(this.BLUE_ANGLE - radians) + rotation,
         )
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/TeleOpMovement.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/TeleOpMovement.kt
@@ -5,7 +5,6 @@ import org.firstinspires.ftc.teamcode.api.TeleOpState
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import kotlin.math.PI
 import kotlin.math.atan2
-import kotlin.math.sin
 import kotlin.math.sqrt
 
 /**
@@ -43,10 +42,6 @@ object TeleOpMovement : Component {
         val joyMagnitude = sqrt(joyY * joyY + joyX * joyX)
 
         // all movement of the wheels
-        TriWheels.power(
-            joyMagnitude * sin(TriWheels.RED_ANGLE - joyRadians) + rotationPower,
-            joyMagnitude * sin(TriWheels.GREEN_ANGLE - joyRadians) + rotationPower,
-            joyMagnitude * sin(TriWheels.BLUE_ANGLE - joyRadians) + rotationPower,
-        )
+        TriWheels.driveWithRotation(joyRadians, joyMagnitude, rotationPower)
     }
 }


### PR DESCRIPTION
These are some smaller changes the cleans up the `TriWheels` API and the `TeleOpMovement` code. It specifically makes it so `TeleOpMovement` does not have to duplicate the `TriWheels.drive()` function. This is ready for review and can be merged once approved.

> [!note]
> I recommend viewing changes one commit at a time, instead of all at once.

# Changes

- Renamed `TriWheels.power()` to `TriWheels.rotate()` to better fit its usage.
  - This is only `power(Double)`, not `power(Double, Double, Double)`.
- Renamed `TriWheels.removeDirection()` to `TriWheels.drive()` to shorten its name.
- Added `TriWheels.driveWithDirection()`.
- Replaced hardcoded movement code in `TeleOpMovement` to use `TriWheels.driveWithDirection()`.
- Make the wheel angle constants private, since they are no longer needed.

All renamed functions have been marked as deprecated. You can still use them, but they will generate a warning. In the future, it will generate a hard error when you use them.