### PR TITLE
Robot Config

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Telemetry.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Telemetry.kt
@@ -5,6 +5,7 @@ import com.acmerobotics.dashboard.telemetry.MultipleTelemetry
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import org.firstinspires.ftc.teamcode.api.Telemetry.sayInitialized
 import org.firstinspires.ftc.teamcode.api.Telemetry.sayRunning
+import org.firstinspires.ftc.teamcode.utils.RobotConfig
 
 /**
  * An API for handling telemetry feedback.
@@ -28,8 +29,13 @@ object Telemetry : API() {
         )
     }
 
+    /** This additionally logs the current [RobotConfig]. */
     fun sayInitialized() = with(opMode.telemetry) {
         addData("Status", "Initialized")
+
+        // Log the current robot configuration
+        addData("Config", RobotConfig.toString())
+
         update()
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/linear/Encoders.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/linear/Encoders.kt
@@ -1,12 +1,12 @@
 package org.firstinspires.ftc.teamcode.api.linear
 
-import com.acmerobotics.dashboard.config.Config
 import com.qualcomm.robotcore.hardware.DcMotor
 import com.qualcomm.robotcore.hardware.DcMotorSimple
 import com.qualcomm.robotcore.util.ElapsedTime
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.api.linear.Encoders.driveTo
 import org.firstinspires.ftc.teamcode.api.linear.Encoders.spinTo
+import org.firstinspires.ftc.teamcode.utils.RobotConfig
 import kotlin.math.abs
 import kotlin.math.min
 
@@ -22,33 +22,11 @@ import kotlin.math.min
  * @see spinTo
  */
 object Encoders : LinearAPI() {
-    @Config
-    private object EncodersConfig {
-        @JvmField
-        var TICKS_PER_INCH: Double = 44.0
+    private fun inchesToTick(inches: Double): Int =
+        (RobotConfig.Encoders.TICKS_PER_INCH * inches).toInt()
 
-        @JvmField
-        var TICKS_PER_DEGREE: Double = 6.64
-
-        @JvmField
-        var ENCODER_GAIN: Double = 0.0003
-
-        @JvmField
-        var ENCODER_ERROR: Int = 10
-
-        @JvmField
-        var MAX_DRIVE_SPEED: Double = 0.3
-
-        @JvmField
-        var MAX_SPIN_SPEED: Double = 0.8
-
-        @JvmField
-        var TIME_GAIN: Double = 0.4
-    }
-
-    private fun inchesToTick(inches: Double): Int = (EncodersConfig.TICKS_PER_INCH * inches).toInt()
     private fun degreesToTick(degrees: Double): Int =
-        (EncodersConfig.TICKS_PER_DEGREE * degrees).toInt()
+        (RobotConfig.Encoders.TICKS_PER_DEGREE * degrees).toInt()
 
     /**
      * Drives the robot in a given [direction] a certain amount of [inches].
@@ -75,26 +53,26 @@ object Encoders : LinearAPI() {
             val runtime = ElapsedTime()
 
             while (
-                abs(left.currentPosition - leftTarget) > EncodersConfig.ENCODER_ERROR &&
-                abs(right.currentPosition - rightTarget) > EncodersConfig.ENCODER_ERROR &&
+                abs(left.currentPosition - leftTarget) > RobotConfig.Encoders.ENCODER_ERROR &&
+                abs(right.currentPosition - rightTarget) > RobotConfig.Encoders.ENCODER_ERROR &&
                 linearOpMode.opModeIsActive()
             ) {
                 // Accelerate the longer the robot has been running
-                val timeSpeed = runtime.seconds() * EncodersConfig.TIME_GAIN
+                val timeSpeed = runtime.seconds() * RobotConfig.Encoders.TIME_GAIN
 
                 left.power =
                     min(
                         min(
-                            abs(left.currentPosition - leftTarget) * EncodersConfig.ENCODER_GAIN,
+                            abs(left.currentPosition - leftTarget) * RobotConfig.Encoders.ENCODER_GAIN,
                             timeSpeed
-                        ), EncodersConfig.MAX_DRIVE_SPEED
+                        ), RobotConfig.Encoders.MAX_DRIVE_SPEED
                     )
                 right.power =
                     min(
                         min(
-                            abs(right.currentPosition - rightTarget) * EncodersConfig.ENCODER_GAIN,
+                            abs(right.currentPosition - rightTarget) * RobotConfig.Encoders.ENCODER_GAIN,
                             timeSpeed
-                        ), EncodersConfig.MAX_DRIVE_SPEED
+                        ), RobotConfig.Encoders.MAX_DRIVE_SPEED
                     )
 
                 with(linearOpMode.telemetry) {
@@ -149,15 +127,15 @@ object Encoders : LinearAPI() {
                 linearOpMode.opModeIsActive()
             ) {
                 // Accelerate the longer the robot has been running
-                val timeSpeed = runtime.seconds() * EncodersConfig.TIME_GAIN
+                val timeSpeed = runtime.seconds() * RobotConfig.Encoders.TIME_GAIN
 
                 TriWheels.rotate(
                     min(
                         min(
-                            abs(TriWheels.red.currentPosition - TriWheels.red.targetPosition) * EncodersConfig.ENCODER_GAIN,
+                            abs(TriWheels.red.currentPosition - TriWheels.red.targetPosition) * RobotConfig.Encoders.ENCODER_GAIN,
                             timeSpeed,
                         ),
-                        EncodersConfig.MAX_SPIN_SPEED
+                        RobotConfig.Encoders.MAX_SPIN_SPEED
                     )
                 )
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
@@ -1,0 +1,39 @@
+package org.firstinspires.ftc.teamcode.utils
+
+import com.acmerobotics.dashboard.config.Config
+
+object RobotConfig {
+    val model: Model = Model.Mark0
+
+    @Config
+    object Encoders {
+        @JvmField
+        var TICKS_PER_INCH: Double = 44.0
+
+        @JvmField
+        var TICKS_PER_DEGREE: Double = 6.64
+
+        @JvmField
+        var ENCODER_GAIN: Double = 0.0003
+
+        @JvmField
+        var ENCODER_ERROR: Int = 10
+
+        @JvmField
+        var MAX_DRIVE_SPEED: Double = 0.3
+
+        @JvmField
+        var MAX_SPIN_SPEED: Double = 0.8
+
+        @JvmField
+        var TIME_GAIN: Double = 0.4
+    }
+
+    enum class Model {
+        // This year's robot's first version.
+        Mark1,
+
+        // Last year's version.
+        Mark0,
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
@@ -1,39 +1,92 @@
 package org.firstinspires.ftc.teamcode.utils
 
 import com.acmerobotics.dashboard.config.Config
+import org.firstinspires.ftc.teamcode.utils.RobotConfig.model
 
+/**
+ * This is an immutable object representing robot configuration.
+ *
+ * It is meant to orchestrate FTC Dashboard and other configuration together, as well as enable the
+ * use of multiple different robots with the same code. (See [model].)
+ *
+ * Certain sub-objects are annotated with `@Config`. This designates them as FTC Dashboard
+ * configuration that can be modified at runtime. **The permanently change these values, you must
+ * also modify the code!** The configuration can also change during initialization depending on the
+ * [model] of the robot and other values.
+ */
 object RobotConfig {
-    val model: Model = Model.Mark0
+    /**
+     * Which model of the robot is running the code.
+     *
+     * @see Model
+     */
+    val model: Model = Model.RobotB
 
+    /** Configuration related to moving the wheels using encoders. */
     @Config
     object Encoders {
+        /**
+         * How many ticks a wheel needs to rotate for the robot to travel an inch when moving along
+         * one of it's three axis.
+         *
+         * This value was calculated by guessing and checking, and may be further changed to
+         * increase accuracy.
+         */
         @JvmField
         var TICKS_PER_INCH: Double = 44.0
 
+        /**
+         * How many ticks a wheel needs to rotate for the robot to spin a single degree.
+         *
+         * This value was calculated by guessing and checking, and may be further changed to
+         * increase accuracy.
+         */
         @JvmField
         var TICKS_PER_DEGREE: Double = 6.64
 
+        /**
+         * A multiplier that calculates the power of the wheel relative to the amount it needs to
+         * rotate.
+         */
         @JvmField
         var ENCODER_GAIN: Double = 0.0003
 
+        /**
+         * How many ticks a wheel needs to be within the target to be considered finished.
+         */
         @JvmField
         var ENCODER_ERROR: Int = 10
 
+        /**
+         * The maximum power a wheel can spin at when the robot is driving with encoders.
+         */
         @JvmField
         var MAX_DRIVE_SPEED: Double = 0.3
 
+        /**
+         * The maximum power a wheel can spin at when the robot spinning with encoders.
+         */
         @JvmField
         var MAX_SPIN_SPEED: Double = 0.8
 
+        /**
+         * A multiplier that calculates the power of the wheel relative to the amount of time that
+         * has passed.
+         */
         @JvmField
         var TIME_GAIN: Double = 0.4
     }
 
+    /**
+     * Represents what model of robot is running the code.
+     *
+     * @see model
+     */
     enum class Model {
-        // This year's robot's first version.
-        Mark1,
+        /** This year's triangle robot. */
+        RobotA,
 
-        // Last year's version.
-        Mark0,
+        /** Last year's triangle robot. */
+        RobotB,
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
@@ -22,6 +22,14 @@ object RobotConfig {
      */
     val model: Model = Model.RobotB
 
+    /**
+     * Creates a string representing the current robot configuration.
+     *
+     * This should include all standalone properties like [model], but should not contain any FTC
+     * Dashboard configuration due to how much more complicated they are.
+     */
+    override fun toString() = "RobotConfig(model=$model)"
+
     /** Configuration related to moving the wheels using encoders. */
     @Config
     object Encoders {


### PR DESCRIPTION
This is the beginning of my attempts to migrate the code to the new robot (Mark 1). It creates a new object called `RobotConfig` which tracks all FTC Dashboard config objects. It also adds a `Model` enum, which specifies which robot model is being used.