### PR TITLE
Teamcode documentation (Dokka)

### DIFF
--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -11,6 +11,10 @@
 
 // Custom definitions may go here
 
+plugins {
+    id 'org.jetbrains.dokka' version '1.9.10'
+}
+
 // Include common definitions from above.
 apply from: '../build.common.gradle'
 apply from: '../build.dependencies.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-
 # Allow Gradle to use up to 1 GB of RAM
 org.gradle.jvmargs=-Xmx1024M
+# Force Kotlin official code style
+kotlin.code.style=official


### PR DESCRIPTION
This automatically builds and publishes the documentation for the Teamcode module to a website, which is easier to read than the raw source code.