### PR TITLE
Debug Toggle Configurations

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Telemetry.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Telemetry.kt
@@ -22,11 +22,13 @@ object Telemetry : API() {
     override fun init(opMode: OpMode) {
         super.init(opMode)
 
-        // Makes opMode.telemetry calls send to both driver station and FTC Dashboard
-        opMode.telemetry = MultipleTelemetry(
-            opMode.telemetry,
-            FtcDashboard.getInstance().telemetry,
-        )
+        if (RobotConfig.debug) {
+            // Makes opMode.telemetry calls send to both driver station and FTC Dashboard
+            opMode.telemetry = MultipleTelemetry(
+                opMode.telemetry,
+                FtcDashboard.getInstance().telemetry,
+            )
+        }
     }
 
     /** This additionally logs the current [RobotConfig]. */

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/Vision.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/Vision.kt
@@ -4,6 +4,7 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import org.firstinspires.ftc.robotcore.external.hardware.camera.WebcamName
 import org.firstinspires.ftc.teamcode.api.API
+import org.firstinspires.ftc.teamcode.utils.RobotConfig
 import org.firstinspires.ftc.vision.VisionPortal
 
 object Vision : API() {
@@ -29,7 +30,8 @@ object Vision : API() {
         // Configure the builder with settings
         val builder = VisionPortal.Builder()
             .setCamera(webcam)
-            .enableLiveView(true)
+            // Enable live view when debug is enabled
+            .enableLiveView(RobotConfig.debug)
 
         // Add all of the processors
         for (visionAPI in visionAPIs) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
@@ -23,12 +23,19 @@ object RobotConfig {
     val model: Model = Model.RobotB
 
     /**
+     * When true, enables debugging features like camera streaming and more logs.
+     *
+     * This should be disabled for competitions.
+     */
+    const val debug: Boolean = true
+
+    /**
      * Creates a string representing the current robot configuration.
      *
-     * This should include all standalone properties like [model], but should not contain any FTC
-     * Dashboard configuration due to how much more complicated they are.
+     * This should include all standalone properties like [model] and [debug], but should not
+     * contain any FTC Dashboard configuration due to how much more complicated they are.
      */
-    override fun toString() = "RobotConfig(model=$model)"
+    override fun toString() = "RobotConfig(model=$model, debug=$debug)"
 
     /** Configuration related to moving the wheels using encoders. */
     @Config


### PR DESCRIPTION
This adds a boolean property to `RobotConfig` that allows you to toggle certain debug features. These features are those that should not be enabled during competition. Currently it includes:

- Emitting telemetry to FTC Dashboard
- Streaming the camera feed to the driver station (live view)

In the future, I want to use this with #29 to toggle off streaming the camera to FTC Dashboard as well.

https://github.com/BotsBurgh/BOTSBURGH-FTC-2023-24/blob/6bb6037bafcc06460309bad13b3fb386efafdbd9/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/AutoMain.kt#L46-L48