### PR TITLE
Reset notifier

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/DemoAutonomous.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/DemoAutonomous.kt
@@ -6,15 +6,11 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import org.firstinspires.ftc.teamcode.api.DemoQuadWheels
 import org.firstinspires.ftc.teamcode.api.Telemetry
 import org.firstinspires.ftc.teamcode.components.linear.DemoSpinLinear
-import org.firstinspires.ftc.teamcode.utils.Reset
 
 @Autonomous(name = "Demo Autonomous")
 @Disabled
 class DemoAutonomous : LinearOpMode() {
     override fun runOpMode() {
-        // Reset is a special utility necessary in all opmodes.
-        Reset.init(this)
-
         // Setup special telemetry
         Telemetry.init(this)
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/DemoTeleOp.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/DemoTeleOp.kt
@@ -8,16 +8,12 @@ import org.firstinspires.ftc.teamcode.api.Telemetry
 import org.firstinspires.ftc.teamcode.api.vision.AprilVision
 import org.firstinspires.ftc.teamcode.api.vision.Vision
 import org.firstinspires.ftc.teamcode.components.DemoForward
-import org.firstinspires.ftc.teamcode.utils.Reset
 
 @TeleOp(name = "Demo TeleOp")
 @Disabled
 class DemoTeleOp : OpMode() {
     // Run once, when "Init" is pressed on driver hub.
     override fun init() {
-        // Reset is a special utility necessary in all opmodes.
-        Reset.init(this)
-
         // Setup special telemetry
         Telemetry.init(this)
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.kt
@@ -8,15 +8,11 @@ import org.firstinspires.ftc.teamcode.api.Telemetry
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.components.DPadCommands
 import org.firstinspires.ftc.teamcode.components.TeleOpMovement
-import org.firstinspires.ftc.teamcode.utils.Reset
 
 @TeleOp(name = "TeleOpMain")
 class TeleOpMain : OpMode() {
     // init will run once
     override fun init() {
-        // Resets property states of the robot
-        Reset.init(this)
-
         // Setup special telemetry
         Telemetry.init(this)
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
@@ -1,6 +1,10 @@
 package org.firstinspires.ftc.teamcode.utils
 
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import com.qualcomm.robotcore.eventloop.opmode.OpModeManager
+import com.qualcomm.robotcore.eventloop.opmode.OpModeManagerImpl
+import com.qualcomm.robotcore.eventloop.opmode.OpModeManagerNotifier
+import com.qualcomm.robotcore.eventloop.opmode.OpModeRegistrar
 import kotlin.reflect.KProperty
 
 /**
@@ -8,38 +12,33 @@ import kotlin.reflect.KProperty
  */
 private val resetFunctions = mutableSetOf<() -> Unit>()
 
-/**
- * An object that resets the property states of the robot, used between opmode runs.
- *
- * **This must be initialized first, before any other code is run!**
- *
- * @see Resettable
- */
-object Reset {
-    /**
-     * A reference to the last-initialized opmode, used purely to ensure that [Reset] is not called
-     * more than once per run.
-     */
-    private var opModeReference: OpMode? = null
-
-    /** Resets any registered [Resettable] properties. */
-    fun init(opMode: OpMode) {
-        // Check that, if Reset has been called before, it is not called on the same opmode run by
-        // ensuring the opmode references are different.
-        if (opModeReference == opMode) {
-            throw IllegalStateException("Tried to initialize the Reset API more than once in a single run.")
+object ResetNotifier : OpModeManagerNotifier.Notifications {
+    @OpModeRegistrar
+    @JvmStatic
+    fun register(manager: OpModeManager) {
+        if (manager is OpModeManagerImpl) {
+            manager.registerListener(this)
         }
-
-        // Set new opmode reference.
-        opModeReference = opMode
-
-        // Reset any registered properties.
-        resetAll()
     }
+
+    override fun onOpModePreInit(opMode: OpMode?) {
+        this.resetAll()
+    }
+
+    override fun onOpModePreStart(opMode: OpMode?) {}
+    override fun onOpModePostStop(opMode: OpMode?) {}
 
     private fun resetAll() {
         // Call each reset function
         resetFunctions.forEach { it() }
+    }
+
+    @Deprecated(
+        message = "ResetNotifier gets automatically initialized, you do not need to manually do it.",
+        replaceWith = ReplaceWith(""),
+        level = DeprecationLevel.ERROR,
+    )
+    fun init(opMode: OpMode) {
     }
 }
 


### PR DESCRIPTION
This is a PR that removes the need to call `Reset.init(this)` at the beginning of each opmode. Instead, `ResetNotifier` is automatically called before an opmode gets initialized.

This code is slightly more complicated than before, but it prevents us from shooting ourselves in the foot.