### PR TITLE
Cube scanning with OpenCV

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
@@ -95,15 +95,16 @@ object CubeVision : API(), VisionAPI {
 
             val maxScore = max(scoreLeft, scoreCenter)
 
-            this.placement = if (maxScore > RobotConfig.CubeVision.SCORE_THRESHOLD) {
-                 when(maxScore) {
-                    scoreLeft -> CubePlacement.Left
-                    scoreCenter -> CubePlacement.Center
-                    else -> throw RuntimeException("Unreachable")
+            this.placement =
+                if (maxScore > RobotConfig.CubeVision.SCORE_THRESHOLD) {
+                    when (maxScore) {
+                        scoreLeft -> CubePlacement.Left
+                        scoreCenter -> CubePlacement.Center
+                        else -> throw RuntimeException("Unreachable")
+                    }
+                } else {
+                    CubePlacement.Right
                 }
-            } else {
-                CubePlacement.Right
-            }
 
             Imgproc.rectangle(
                 frame,

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
@@ -1,0 +1,76 @@
+package org.firstinspires.ftc.teamcode.api.vision
+
+import android.graphics.Canvas
+import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import org.firstinspires.ftc.robotcore.internal.camera.calibration.CameraCalibration
+import org.firstinspires.ftc.teamcode.api.API
+import org.firstinspires.ftc.teamcode.api.vision.CubeVision.placement
+import org.firstinspires.ftc.vision.VisionProcessor
+import org.opencv.core.Mat
+import kotlin.concurrent.Volatile
+
+/**
+ * A [VisionAPI] that scans for the game piece in its 3 possible positions.
+ *
+ * Note that this is only meant to run in the beginning of the autonomous phase. Afterwards, it can
+ * be disabled with [Vision.disable].
+ *
+ * @see placement
+ */
+object CubeVision : API(), VisionAPI {
+    override val processor: VisionProcessor
+        get() = this.cubeProcessor
+
+    /**
+     * Returns where the cube is currently placed.
+     *
+     * @see CubePlacement
+     */
+    val placement: CubePlacement
+        get() = this.cubeProcessor.placement
+
+    private lateinit var cubeProcessor: CubeProcessor
+
+    override fun init(opMode: OpMode) {
+        super.init(opMode)
+        this.cubeProcessor = CubeProcessor()
+    }
+
+    /**
+     * Represents the position where the cube is placed, relative to the camera of the robot.
+     */
+    enum class CubePlacement {
+        Left,
+        Center,
+        Right,
+    }
+
+    /**
+     * A custom processor for the vision portal that scans for the cube.
+     */
+    private class CubeProcessor : VisionProcessor {
+        // Make reads and writes synchronized, avoiding data races.
+        @Volatile
+        var placement = CubePlacement.Center
+
+        // Initialization code
+        override fun init(width: Int, height: Int, calibration: CameraCalibration?) {}
+
+        // Actual processing of OpenCV frame
+        override fun processFrame(frame: Mat, captureTimeNanos: Long): Any? {
+            // This returned value is the userContext in [onDrawFrame]
+            return null
+        }
+
+        // Allows drawing shapes on stream video
+        override fun onDrawFrame(
+            canvas: Canvas,
+            onscreenWidth: Int,
+            onscreenHeight: Int,
+            scaleBmpPxToCanvasPx: Float,
+            scaleCanvasDensity: Float,
+            userContext: Any?
+        ) {
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
@@ -25,7 +25,10 @@ object CubeVision : API(), VisionAPI {
 
     private lateinit var cubeProcessor: CubeProcessor
 
-    fun init(opMode: OpMode, cubeColor: Team) {
+    fun init(
+        opMode: OpMode,
+        cubeColor: Team,
+    ) {
         super.init(opMode)
         this.cubeProcessor = CubeProcessor(cubeColor, opMode.telemetry)
     }
@@ -52,14 +55,22 @@ object CubeVision : API(), VisionAPI {
         private lateinit var regionRight: Mat
 
         private val colorWeight: Scalar
-            get() = when (this.cubeColor) {
-                Team.Red -> RobotConfig.CubeVision.RED_WEIGHT
-                Team.Blue -> RobotConfig.CubeVision.BLUE_WEIGHT
-            }
+            get() =
+                when (this.cubeColor) {
+                    Team.Red -> RobotConfig.CubeVision.RED_WEIGHT
+                    Team.Blue -> RobotConfig.CubeVision.BLUE_WEIGHT
+                }
 
-        override fun init(width: Int, height: Int, calibration: CameraCalibration?) {}
+        override fun init(
+            width: Int,
+            height: Int,
+            calibration: CameraCalibration?,
+        ) {}
 
-        override fun processFrame(frame: Mat, captureTimeNanos: Long): CubePlacement {
+        override fun processFrame(
+            frame: Mat,
+            captureTimeNanos: Long,
+        ): CubePlacement {
             frame.copyTo(this.rgb)
 
             // Create sub-regions only once.
@@ -82,29 +93,30 @@ object CubeVision : API(), VisionAPI {
                 addData("Score Right", scoreRight)
             }
 
-            val placement = when (max(max(scoreLeft, scoreCenter), scoreRight)) {
-                scoreLeft -> CubePlacement.Left
-                scoreCenter -> CubePlacement.Center
-                scoreRight -> CubePlacement.Right
-                else -> throw RuntimeException("Unreachable")
-            }
+            val placement =
+                when (max(max(scoreLeft, scoreCenter), scoreRight)) {
+                    scoreLeft -> CubePlacement.Left
+                    scoreCenter -> CubePlacement.Center
+                    scoreRight -> CubePlacement.Right
+                    else -> throw RuntimeException("Unreachable")
+                }
 
             this.placement = placement
 
             Imgproc.rectangle(
                 frame,
                 RobotConfig.CubeVision.LEFT_REGION,
-                Scalar(255.0, 255.0, 255.0, 255.0)
+                Scalar(255.0, 255.0, 255.0, 255.0),
             )
             Imgproc.rectangle(
                 frame,
                 RobotConfig.CubeVision.CENTER_REGION,
-                Scalar(255.0, 255.0, 255.0, 255.0)
+                Scalar(255.0, 255.0, 255.0, 255.0),
             )
             Imgproc.rectangle(
                 frame,
                 RobotConfig.CubeVision.RIGHT_REGION,
-                Scalar(255.0, 255.0, 255.0, 255.0)
+                Scalar(255.0, 255.0, 255.0, 255.0),
             )
 
             // This return value is passed to [onDrawFrame].
@@ -123,11 +135,9 @@ object CubeVision : API(), VisionAPI {
 
         fun Scalar.sumRGB(): Double = this.`val`.sum()
 
-        operator fun Rect.times(rhs: Int): Rect =
-            Rect(this.x * rhs, this.y * rhs, this.width * rhs, this.height * rhs)
+        operator fun Rect.times(rhs: Int): Rect = Rect(this.x * rhs, this.y * rhs, this.width * rhs, this.height * rhs)
 
-        fun Rect.toAndroidRect(): android.graphics.Rect =
-            android.graphics.Rect(this.x, this.y, this.x + this.width, this.y + this.height)
+        fun Rect.toAndroidRect(): android.graphics.Rect = android.graphics.Rect(this.x, this.y, this.x + this.width, this.y + this.height)
     }
 
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
@@ -149,6 +149,13 @@ object CubeVision : API(), VisionAPI {
     enum class CubePlacement {
         Left,
         Center,
-        Right,
+        Right, ;
+
+        fun toInt(): Int =
+            when (this) {
+                Left -> 1
+                Center -> 2
+                Right -> 3
+            }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
@@ -4,36 +4,51 @@ import android.graphics.Canvas
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import org.firstinspires.ftc.robotcore.internal.camera.calibration.CameraCalibration
 import org.firstinspires.ftc.teamcode.api.API
-import org.firstinspires.ftc.teamcode.api.vision.CubeVision.placement
+import org.firstinspires.ftc.teamcode.utils.Team
 import org.firstinspires.ftc.vision.VisionProcessor
 import org.opencv.core.Mat
-import kotlin.concurrent.Volatile
 
 /**
- * A [VisionAPI] that scans for the game piece in its 3 possible positions.
+ * A [VisionAPI] / [VisionProcessor] that scans for the game piece in its 3 possible positions.
  *
  * Note that this is only meant to run in the beginning of the autonomous phase. Afterwards, it can
  * be disabled with [Vision.disable].
- *
- * @see placement
  */
-object CubeVision : API(), VisionAPI {
+object CubeVision : API(), VisionAPI, VisionProcessor {
     override val processor: VisionProcessor
-        get() = this.cubeProcessor
+        get() = this
 
     /**
-     * Returns where the cube is currently placed.
-     *
-     * @see CubePlacement
+     * Initializes the API with a given [opMode] and [cubeColor].
      */
-    val placement: CubePlacement
-        get() = this.cubeProcessor.placement
-
-    private lateinit var cubeProcessor: CubeProcessor
-
-    override fun init(opMode: OpMode) {
+    fun init(opMode: OpMode, cubeColor: Team) {
         super.init(opMode)
-        this.cubeProcessor = CubeProcessor()
+    }
+
+    override fun init(width: Int, height: Int, calibration: CameraCalibration?) {}
+
+    override fun processFrame(frame: Mat, captureTimeNanos: Long): Any? {
+        // This returned value is the userContext in [onDrawFrame]
+        return null
+    }
+
+    override fun onDrawFrame(
+        canvas: Canvas,
+        onscreenWidth: Int,
+        onscreenHeight: Int,
+        scaleBmpPxToCanvasPx: Float,
+        scaleCanvasDensity: Float,
+        userContext: Any?,
+    ) {
+    }
+
+    @Deprecated(
+        message = "Please initialize CubeVision with cubeColor.",
+        replaceWith = ReplaceWith("CubeVision.init(this, cubeColor)"),
+        level = DeprecationLevel.ERROR,
+    )
+    override fun init(opMode: OpMode) {
+        throw RuntimeException("Please initialize CubeVision with cubeColor.")
     }
 
     /**
@@ -43,34 +58,5 @@ object CubeVision : API(), VisionAPI {
         Left,
         Center,
         Right,
-    }
-
-    /**
-     * A custom processor for the vision portal that scans for the cube.
-     */
-    private class CubeProcessor : VisionProcessor {
-        // Make reads and writes synchronized, avoiding data races.
-        @Volatile
-        var placement = CubePlacement.Center
-
-        // Initialization code
-        override fun init(width: Int, height: Int, calibration: CameraCalibration?) {}
-
-        // Actual processing of OpenCV frame
-        override fun processFrame(frame: Mat, captureTimeNanos: Long): Any? {
-            // This returned value is the userContext in [onDrawFrame]
-            return null
-        }
-
-        // Allows drawing shapes on stream video
-        override fun onDrawFrame(
-            canvas: Canvas,
-            onscreenWidth: Int,
-            onscreenHeight: Int,
-            scaleBmpPxToCanvasPx: Float,
-            scaleCanvasDensity: Float,
-            userContext: Any?
-        ) {
-        }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/CubeVision.kt
@@ -2,44 +2,32 @@ package org.firstinspires.ftc.teamcode.api.vision
 
 import android.graphics.Canvas
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.robotcore.internal.camera.calibration.CameraCalibration
 import org.firstinspires.ftc.teamcode.api.API
+import org.firstinspires.ftc.teamcode.utils.RobotConfig
 import org.firstinspires.ftc.teamcode.utils.Team
 import org.firstinspires.ftc.vision.VisionProcessor
+import org.opencv.core.Core
 import org.opencv.core.Mat
+import org.opencv.core.Rect
+import org.opencv.core.Scalar
+import org.opencv.imgproc.Imgproc
+import kotlin.concurrent.Volatile
+import kotlin.math.max
 
-/**
- * A [VisionAPI] / [VisionProcessor] that scans for the game piece in its 3 possible positions.
- *
- * Note that this is only meant to run in the beginning of the autonomous phase. Afterwards, it can
- * be disabled with [Vision.disable].
- */
-object CubeVision : API(), VisionAPI, VisionProcessor {
+object CubeVision : API(), VisionAPI {
     override val processor: VisionProcessor
-        get() = this
+        get() = this.cubeProcessor
 
-    /**
-     * Initializes the API with a given [opMode] and [cubeColor].
-     */
+    val output: CubePlacement
+        get() = this.cubeProcessor.placement
+
+    private lateinit var cubeProcessor: CubeProcessor
+
     fun init(opMode: OpMode, cubeColor: Team) {
         super.init(opMode)
-    }
-
-    override fun init(width: Int, height: Int, calibration: CameraCalibration?) {}
-
-    override fun processFrame(frame: Mat, captureTimeNanos: Long): Any? {
-        // This returned value is the userContext in [onDrawFrame]
-        return null
-    }
-
-    override fun onDrawFrame(
-        canvas: Canvas,
-        onscreenWidth: Int,
-        onscreenHeight: Int,
-        scaleBmpPxToCanvasPx: Float,
-        scaleCanvasDensity: Float,
-        userContext: Any?,
-    ) {
+        this.cubeProcessor = CubeProcessor(cubeColor, opMode.telemetry)
     }
 
     @Deprecated(
@@ -48,7 +36,98 @@ object CubeVision : API(), VisionAPI, VisionProcessor {
         level = DeprecationLevel.ERROR,
     )
     override fun init(opMode: OpMode) {
-        throw RuntimeException("Please initialize CubeVision with cubeColor.")
+    }
+
+    private class CubeProcessor(private val cubeColor: Team, private val t: Telemetry) :
+        VisionProcessor {
+        @Volatile
+        var placement = CubePlacement.Center
+
+        private var initialized = false
+
+        private val rgb = Mat()
+
+        private lateinit var regionLeft: Mat
+        private lateinit var regionCenter: Mat
+        private lateinit var regionRight: Mat
+
+        private val colorWeight: Scalar
+            get() = when (this.cubeColor) {
+                Team.Red -> RobotConfig.CubeVision.RED_WEIGHT
+                Team.Blue -> RobotConfig.CubeVision.BLUE_WEIGHT
+            }
+
+        override fun init(width: Int, height: Int, calibration: CameraCalibration?) {}
+
+        override fun processFrame(frame: Mat, captureTimeNanos: Long): CubePlacement {
+            frame.copyTo(this.rgb)
+
+            // Create sub-regions only once.
+            if (!this.initialized) {
+                this.regionLeft = this.rgb.submat(RobotConfig.CubeVision.LEFT_REGION)
+                this.regionCenter = this.rgb.submat(RobotConfig.CubeVision.CENTER_REGION)
+                this.regionRight = this.rgb.submat(RobotConfig.CubeVision.RIGHT_REGION)
+
+                this.initialized = true
+            }
+
+            // Calculate score. The greater, the more likely it is to be the cube we want.
+            val scoreLeft = Core.mean(this.regionLeft).mul(colorWeight).sumRGB()
+            val scoreCenter = Core.mean(this.regionCenter).mul(colorWeight).sumRGB()
+            val scoreRight = Core.mean(this.regionRight).mul(colorWeight).sumRGB()
+
+            with(t) {
+                addData("Score Left", scoreLeft)
+                addData("Score Center", scoreCenter)
+                addData("Score Right", scoreRight)
+            }
+
+            val placement = when (max(max(scoreLeft, scoreCenter), scoreRight)) {
+                scoreLeft -> CubePlacement.Left
+                scoreCenter -> CubePlacement.Center
+                scoreRight -> CubePlacement.Right
+                else -> throw RuntimeException("Unreachable")
+            }
+
+            this.placement = placement
+
+            Imgproc.rectangle(
+                frame,
+                RobotConfig.CubeVision.LEFT_REGION,
+                Scalar(255.0, 255.0, 255.0, 255.0)
+            )
+            Imgproc.rectangle(
+                frame,
+                RobotConfig.CubeVision.CENTER_REGION,
+                Scalar(255.0, 255.0, 255.0, 255.0)
+            )
+            Imgproc.rectangle(
+                frame,
+                RobotConfig.CubeVision.RIGHT_REGION,
+                Scalar(255.0, 255.0, 255.0, 255.0)
+            )
+
+            // This return value is passed to [onDrawFrame].
+            return placement
+        }
+
+        override fun onDrawFrame(
+            canvas: Canvas,
+            onscreenWidth: Int,
+            onscreenHeight: Int,
+            scaleBmpPxToCanvasPx: Float,
+            scaleCanvasDensity: Float,
+            userContext: Any?,
+        ) {
+        }
+
+        fun Scalar.sumRGB(): Double = this.`val`.sum()
+
+        operator fun Rect.times(rhs: Int): Rect =
+            Rect(this.x * rhs, this.y * rhs, this.width * rhs, this.height * rhs)
+
+        fun Rect.toAndroidRect(): android.graphics.Rect =
+            android.graphics.Rect(this.x, this.y, this.x + this.width, this.y + this.height)
     }
 
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/Vision.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/Vision.kt
@@ -44,6 +44,17 @@ object Vision : API() {
 
         val webcam = opMode.hardwareMap.get(WebcamName::class.java, "Webcam 1")
 
+        this.reInit(webcam, *visionAPIs)
+    }
+
+    fun reInit(
+        webcam: WebcamName,
+        vararg visionAPIs: VisionAPI,
+    ) {
+        if (this::portal.isInitialized) {
+            this.portal.close()
+        }
+
         // Configure the builder with settings
         val builder =
             VisionPortal.Builder()
@@ -62,7 +73,7 @@ object Vision : API() {
         // Use a different sleep function depending on whether its a linear opmode or not.
         val sleep =
             if (opMode is LinearOpMode) {
-                opMode::sleep
+                (this.opMode as LinearOpMode)::sleep
             } else {
                 this::opModeSleep
             }
@@ -74,6 +85,9 @@ object Vision : API() {
 
             sleep(50)
         }
+
+        opMode.telemetry.addData("Camera", this.portal.cameraState)
+        opMode.telemetry.update()
     }
 
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/Vision.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/Vision.kt
@@ -76,6 +76,24 @@ object Vision : API() {
         }
     }
 
+    /**
+     * Enables a [VisionAPI] that was previously disabled with [disable].
+     *
+     * @throws IllegalArgumentException If [VisionAPI] is not initialized with vision portal.
+     * @see disable
+     */
+    fun enable(visionAPI: VisionAPI) = this.portal.setProcessorEnabled(visionAPI.processor, true)
+
+    /**
+     * Disables a [VisionAPI] so it does not process any frames and does not modify the camera stream.
+     *
+     * This can be used to save resources so no unneeded work is done in the background.
+     *
+     * @throws IllegalArgumentException If [VisionAPI] is not initialized with vision portal.
+     * @see enable
+     */
+    fun disable(visionAPI: VisionAPI) = this.portal.setProcessorEnabled(visionAPI.processor, false)
+
     // Vision must be initialized with at least one VisionAPI
     override fun init(opMode: OpMode) {
         throw RuntimeException("Please initialize Vision with at least one VisionAPI.")

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/Vision.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/vision/Vision.kt
@@ -94,7 +94,11 @@ object Vision : API() {
      */
     fun disable(visionAPI: VisionAPI) = this.portal.setProcessorEnabled(visionAPI.processor, false)
 
-    // Vision must be initialized with at least one VisionAPI
+    @Deprecated(
+        message = "Please initialize Vision with at least one VisionAPI.",
+        replaceWith = ReplaceWith("Vision.init(this, visionAPI)"),
+        level = DeprecationLevel.ERROR,
+    )
     override fun init(opMode: OpMode) {
         throw RuntimeException("Please initialize Vision with at least one VisionAPI.")
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
@@ -135,16 +135,19 @@ object RobotConfig {
         var LEFT_REGION = Rect(100, 200, 100, 100)
 
         @JvmField
-        var CENTER_REGION = Rect(250, 200, 100, 100)
+        var CENTER_REGION = Rect(400, 200, 100, 100)
 
-        @JvmField
-        var RIGHT_REGION = Rect(400, 200, 100, 100)
+        // @JvmField
+        // var RIGHT_REGION = Rect(400, 200, 100, 100)
 
         @JvmField
         var RED_WEIGHT = Scalar(1.0, -0.2, -0.2)
 
         @JvmField
         var BLUE_WEIGHT = Scalar(-0.2, -0.2, 1.0)
+
+        @JvmField
+        var SCORE_THRESHOLD: Double = 150.0
     }
 
     @Config

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
@@ -4,6 +4,8 @@ package org.firstinspires.ftc.teamcode.utils
 
 import com.acmerobotics.dashboard.config.Config
 import org.firstinspires.ftc.teamcode.utils.RobotConfig.model
+import org.opencv.core.Rect
+import org.opencv.core.Scalar
 
 /**
  * This is an immutable object representing robot configuration.
@@ -127,6 +129,24 @@ object RobotConfig {
     }
 
     /** Configuration related to the main autonomous. */
+    @Config
+    object CubeVision {
+        @JvmField
+        var LEFT_REGION = Rect(100, 200, 100, 100)
+
+        @JvmField
+        var CENTER_REGION = Rect(250, 200, 100, 100)
+
+        @JvmField
+        var RIGHT_REGION = Rect(400, 200, 100, 100)
+
+        @JvmField
+        var RED_WEIGHT = Scalar(1.0, -0.2, -0.2)
+
+        @JvmField
+        var BLUE_WEIGHT = Scalar(-0.2, -0.2, 1.0)
+    }
+
     @Config
     object AutoMain {
         @JvmField


### PR DESCRIPTION
- [x] Setup `VisionAPI`
- [x] Draft empty vision processor
- [x] Scan for cube placement
- [x] Draw submats to live preview
  - [ ] Move drawing out of `processFrame` and into `onDrawFrame`
- [x] Add to `AutoMain`, disable after processing finished
  - [ ] Run during initialization as well as start
    - Check rulebook if this is allowed
  - [ ] Test if adding a `sleep` call is useful when processing
  - [ ] Add feedback lights during init