### PR TITLE
Logging suite

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Log.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Log.kt
@@ -1,16 +1,20 @@
 package org.firstinspires.ftc.teamcode.api
 
+import android.content.Context
 import com.acmerobotics.dashboard.FtcDashboard
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket
+import com.qualcomm.ftccommon.FtcEventLoop
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import com.qualcomm.robotcore.eventloop.opmode.OpModeManagerNotifier
 import com.qualcomm.robotcore.util.RobotLog
+import org.firstinspires.ftc.ftccommon.external.OnCreateEventLoop
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.robotcore.internal.system.AppUtil
 import java.io.BufferedWriter
 import java.io.File
 import java.io.FileWriter
 
-object Log : API() {
+object Log : API(), OpModeManagerNotifier.Notifications {
     private val telemetry: Telemetry
         get() = this.opMode.telemetry
 
@@ -81,6 +85,22 @@ object Log : API() {
 
         // Log to Logcat / internal FTC log
         RobotLog.internalLog(level.toAndroid(), this.ROBOT_LOG_TAG, msgString)
+    }
+
+    @OnCreateEventLoop
+    @JvmStatic
+    fun registerFlush(
+        @Suppress("UNUSED_PARAMETER") context: Context,
+        ftcEventLoop: FtcEventLoop,
+    ) {
+        ftcEventLoop.opModeManager.registerListener(this)
+    }
+
+    override fun onOpModePreInit(opMode: OpMode?) {}
+    override fun onOpModePreStart(opMode: OpMode?) {}
+    override fun onOpModePostStop(opMode: OpMode?) {
+        RobotLog.dd(this.ROBOT_LOG_TAG, "Flushing log to BotsBurgh/latest.log")
+        this.flush()
     }
 
     enum class Level {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Log.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Log.kt
@@ -1,0 +1,101 @@
+package org.firstinspires.ftc.teamcode.api
+
+import com.acmerobotics.dashboard.FtcDashboard
+import com.acmerobotics.dashboard.telemetry.TelemetryPacket
+import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import com.qualcomm.robotcore.util.RobotLog
+import org.firstinspires.ftc.robotcore.external.Telemetry
+import org.firstinspires.ftc.robotcore.internal.system.AppUtil
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileWriter
+
+object Log : API() {
+    private val telemetry: Telemetry
+        get() = this.opMode.telemetry
+
+    private val telemetryLog: Telemetry.Log
+        get() = this.opMode.telemetry.log()
+
+    private val dashboard: FtcDashboard
+        get() = FtcDashboard.getInstance()
+
+    private const val ROBOT_LOG_TAG = "BOTSBURGH"
+
+    private val botsburghFolder = File(AppUtil.ROOT_FOLDER, "/BotsBurgh/")
+    private val logFile = File(this.botsburghFolder, "/latest.log")
+    private val logWriter = BufferedWriter(FileWriter(this.logFile))
+
+    init {
+        this.botsburghFolder.mkdirs()
+        this.logFile.createNewFile()
+    }
+
+    override fun init(opMode: OpMode) {
+        super.init(opMode)
+
+        with(this.logWriter) {
+            write("BotsBurgh 11792 FTC 2023-24")
+            newLine()
+
+            newLine()
+
+            flush()
+        }
+    }
+
+    fun flush() {
+        this.logWriter.flush()
+    }
+
+    fun debug(msg: Any) = this.log(Level.Debug, msg)
+
+    fun info(msg: Any) = this.log(Level.Info, msg)
+
+    fun warn(msg: Any) = this.log(Level.Warn, msg)
+
+    fun error(msg: Any) = this.log(Level.Error, msg)
+
+    private fun log(
+        level: Level,
+        msg: Any,
+    ) {
+        val msgString = msg.toString()
+        val formatted = "[$level] $msgString"
+
+        // Log to driver hub
+        this.telemetryLog.add(formatted)
+
+        // Log to FTC Dashboard
+        this.dashboard.sendTelemetryPacket(
+            TelemetryPacket().apply {
+                this.addLine(formatted)
+            },
+        )
+
+        // Log to BotsBurgh latest.log
+        with(this.logWriter) {
+            write(formatted)
+            newLine()
+        }
+
+        // Log to Logcat / internal FTC log
+        RobotLog.internalLog(level.toAndroid(), this.ROBOT_LOG_TAG, msgString)
+    }
+
+    enum class Level {
+        Debug,
+        Info,
+        Warn,
+        Error,
+        ;
+
+        fun toAndroid(): Int =
+            when (this) {
+                Debug -> android.util.Log.DEBUG
+                Info -> android.util.Log.INFO
+                Warn -> android.util.Log.WARN
+                Error -> android.util.Log.ERROR
+            }
+    }
+}


### PR DESCRIPTION
Adds a more in-depth logging API, hopefully to replace the [`Telemetry`](https://github.com/BotsBurgh/BOTSBURGH-FTC-2023-24/blob/2bb53fc4a203fadcfd8778b17ef983b45de3f869/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Telemetry.kt) API.

Supersedes: #43