### PR TITLE
Reset listener

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/AutoForward.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/AutoForward.kt
@@ -5,14 +5,11 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import org.firstinspires.ftc.teamcode.api.Telemetry
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.api.linear.Encoders
-import org.firstinspires.ftc.teamcode.utils.Reset
 import org.firstinspires.ftc.teamcode.utils.RobotConfig
 
 @Autonomous(name = "Auto Forward")
 class AutoForward : LinearOpMode() {
     override fun runOpMode() {
-        Reset.init(this)
-
         Telemetry.init(this)
         TriWheels.init(this)
         Encoders.init(this)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/AutoMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/AutoMain.kt
@@ -5,7 +5,6 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import org.firstinspires.ftc.teamcode.api.Telemetry
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.api.linear.Encoders
-import org.firstinspires.ftc.teamcode.utils.Reset
 import org.firstinspires.ftc.teamcode.utils.RobotConfig
 import org.firstinspires.ftc.teamcode.utils.Team
 
@@ -26,8 +25,6 @@ abstract class AutoMain : LinearOpMode() {
     private val tileSize = 24.0
 
     override fun runOpMode() {
-        Reset.init(this)
-
         Telemetry.init(this)
         TriWheels.init(this)
         Encoders.init(this)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/DemoAutonomous.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/DemoAutonomous.kt
@@ -6,15 +6,11 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import org.firstinspires.ftc.teamcode.api.DemoQuadWheels
 import org.firstinspires.ftc.teamcode.api.Telemetry
 import org.firstinspires.ftc.teamcode.components.linear.DemoSpinLinear
-import org.firstinspires.ftc.teamcode.utils.Reset
 
 @Autonomous(name = "Demo Autonomous")
 @Disabled
 class DemoAutonomous : LinearOpMode() {
     override fun runOpMode() {
-        // Reset is a special utility necessary in all opmodes.
-        Reset.init(this)
-
         // Setup special telemetry
         Telemetry.init(this)
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/DemoTeleOp.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/DemoTeleOp.kt
@@ -8,16 +8,12 @@ import org.firstinspires.ftc.teamcode.api.Telemetry
 import org.firstinspires.ftc.teamcode.api.vision.AprilVision
 import org.firstinspires.ftc.teamcode.api.vision.Vision
 import org.firstinspires.ftc.teamcode.components.DemoForward
-import org.firstinspires.ftc.teamcode.utils.Reset
 
 @TeleOp(name = "Demo TeleOp")
 @Disabled
 class DemoTeleOp : OpMode() {
     // Run once, when "Init" is pressed on driver hub.
     override fun init() {
-        // Reset is a special utility necessary in all opmodes.
-        Reset.init(this)
-
         // Setup special telemetry
         Telemetry.init(this)
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.kt
@@ -6,15 +6,11 @@ import org.firstinspires.ftc.teamcode.api.GamepadEx
 import org.firstinspires.ftc.teamcode.api.Telemetry
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.components.TeleOpMovement
-import org.firstinspires.ftc.teamcode.utils.Reset
 
 @TeleOp(name = "TeleOpMain")
 class TeleOpMain : OpMode() {
     // init will run once
     override fun init() {
-        // Resets property states of the robot
-        Reset.init(this)
-
         // Setup special telemetry
         Telemetry.init(this)
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
@@ -15,7 +15,10 @@ private val resetFunctions = mutableSetOf<() -> Unit>()
 object ResetNotifier : OpModeManagerNotifier.Notifications {
     @OnCreateEventLoop
     @JvmStatic
-    fun register(context: Context, ftcEventLoop: FtcEventLoop) {
+    fun register(
+        @Suppress("UNUSED_PARAMETER") context: Context,
+        ftcEventLoop: FtcEventLoop,
+    ) {
         ftcEventLoop.opModeManager.registerListener(this)
     }
 
@@ -24,6 +27,7 @@ object ResetNotifier : OpModeManagerNotifier.Notifications {
     }
 
     override fun onOpModePreStart(opMode: OpMode?) {}
+
     override fun onOpModePostStop(opMode: OpMode?) {}
 
     private fun resetAll() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
@@ -1,6 +1,10 @@
 package org.firstinspires.ftc.teamcode.utils
 
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import com.qualcomm.robotcore.eventloop.opmode.OpModeManager
+import com.qualcomm.robotcore.eventloop.opmode.OpModeManagerImpl
+import com.qualcomm.robotcore.eventloop.opmode.OpModeManagerNotifier
+import com.qualcomm.robotcore.eventloop.opmode.OpModeRegistrar
 import kotlin.reflect.KProperty
 
 /**
@@ -8,38 +12,33 @@ import kotlin.reflect.KProperty
  */
 private val resetFunctions = mutableSetOf<() -> Unit>()
 
-/**
- * An object that resets the property states of the robot, used between opmode runs.
- *
- * **This must be initialized first, before any other code is run!**
- *
- * @see Resettable
- */
-object Reset {
-    /**
-     * A reference to the last-initialized opmode, used purely to ensure that [Reset] is not called
-     * more than once per run.
-     */
-    private var opModeReference: OpMode? = null
-
-    /** Resets any registered [Resettable] properties. */
-    fun init(opMode: OpMode) {
-        // Check that, if Reset has been called before, it is not called on the same opmode run by
-        // ensuring the opmode references are different.
-        if (opModeReference == opMode) {
-            throw IllegalStateException("Tried to initialize the Reset API more than once in a single run.")
+object ResetNotifier : OpModeManagerNotifier.Notifications {
+    @OpModeRegistrar
+    @JvmStatic
+    fun register(manager: OpModeManager) {
+        if (manager is OpModeManagerImpl) {
+            manager.registerListener(this)
         }
-
-        // Set new opmode reference.
-        opModeReference = opMode
-
-        // Reset any registered properties.
-        resetAll()
     }
+
+    override fun onOpModePreInit(opMode: OpMode?) {
+        this.resetAll()
+    }
+
+    override fun onOpModePreStart(opMode: OpMode?) {}
+    override fun onOpModePostStop(opMode: OpMode?) {}
 
     private fun resetAll() {
         // Call each reset function
         resetFunctions.forEach { it() }
+    }
+
+    @Deprecated(
+        message = "ResetNotifier gets automatically initialized, you do not need to manually do it.",
+        replaceWith = ReplaceWith(""),
+        level = DeprecationLevel.ERROR,
+    )
+    fun init(opMode: OpMode) {
     }
 }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
@@ -1,10 +1,10 @@
 package org.firstinspires.ftc.teamcode.utils
 
+import android.content.Context
+import com.qualcomm.ftccommon.FtcEventLoop
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
-import com.qualcomm.robotcore.eventloop.opmode.OpModeManager
-import com.qualcomm.robotcore.eventloop.opmode.OpModeManagerImpl
 import com.qualcomm.robotcore.eventloop.opmode.OpModeManagerNotifier
-import com.qualcomm.robotcore.eventloop.opmode.OpModeRegistrar
+import org.firstinspires.ftc.ftccommon.external.OnCreateEventLoop
 import kotlin.reflect.KProperty
 
 /**
@@ -13,12 +13,10 @@ import kotlin.reflect.KProperty
 private val resetFunctions = mutableSetOf<() -> Unit>()
 
 object ResetNotifier : OpModeManagerNotifier.Notifications {
-    @OpModeRegistrar
+    @OnCreateEventLoop
     @JvmStatic
-    fun register(manager: OpModeManager) {
-        if (manager is OpModeManagerImpl) {
-            manager.registerListener(this)
-        }
+    fun register(context: Context, ftcEventLoop: FtcEventLoop) {
+        ftcEventLoop.opModeManager.registerListener(this)
     }
 
     override fun onOpModePreInit(opMode: OpMode?) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Reset.kt
@@ -30,14 +30,6 @@ object ResetNotifier : OpModeManagerNotifier.Notifications {
         // Call each reset function
         resetFunctions.forEach { it() }
     }
-
-    @Deprecated(
-        message = "ResetNotifier gets automatically initialized, you do not need to manually do it.",
-        replaceWith = ReplaceWith(""),
-        level = DeprecationLevel.ERROR,
-    )
-    fun init(opMode: OpMode) {
-    }
 }
 
 /**


### PR DESCRIPTION
A fixed version of #32.

This removes the need to call `Reset.init(this)` at the beginning of every single opmode. Instead, `ResetNotifier.resetAll()` is automatically called when before an opmode is initialized. This works through the `@OnCreateEventLoop` entrypoint and `OpModeManagerNotifier.Notifications`.