### PR TITLE
Clean up RobotConfig

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.kt
@@ -46,8 +46,6 @@ class TeleOpMain : OpMode() {
         // alias gamepad1
         val gamepad = this.gamepad1
 
-        val rotationPower = RobotConfig.TeleOpMovement.ROTATION_GAIN * -gamepad.right_stick_x.toDouble()
-
         // joystick input
         val joyX = -gamepad.left_stick_x.toDouble()
         val joyY = gamepad.left_stick_y.toDouble()
@@ -63,6 +61,8 @@ class TeleOpMain : OpMode() {
                 }
 
         val joyMagnitude = sqrt(joyY * joyY + joyX * joyX)
+
+        val rotationPower = -gamepad.right_stick_x.toDouble()
 
         // Lock or unlock the slide "brake"
         if (gamepad.dpad_left) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.kt
@@ -85,7 +85,7 @@ class TeleOpMain : OpMode() {
         } else {
             // Manually move slide up and down
             if (gamepad.dpad_down) {
-                LinearSlide.power(RobotConfig.TeleOpMovement.SLIDE_DOWN_POWER)
+                LinearSlide.power(-RobotConfig.TeleOpMovement.SLIDE_DOWN_POWER)
             } else if (gamepad.dpad_up) {
                 LinearSlide.power(RobotConfig.TeleOpMovement.SLIDE_UP_POWER)
             } else {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
@@ -169,9 +169,6 @@ object RobotConfig {
         @JvmField
         var ROTATION_GAIN: Double = 0.6
 
-        @JvmField
-        var SLOW_MULTIPLIER: Double = 0.4
-
         /** The speed at which the linear slide moves upwards. */
         @JvmField
         var SLIDE_UP_POWER: Double = 0.6

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
@@ -171,7 +171,7 @@ object RobotConfig {
 
         /** The speed at which the linear slide moves downwards. */
         @JvmField
-        var SLIDE_DOWN_POWER: Double = -0.4
+        var SLIDE_DOWN_POWER: Double = 0.4
     }
 
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
@@ -163,11 +163,7 @@ object RobotConfig {
 
         /** A multiplier that scales the robot's rotation speed. */
         @JvmField
-        var ROTATE_SPEED: Double = 0.5
-
-        /** A multiplier that scales the robot's rotation speed. */
-        @JvmField
-        var ROTATION_GAIN: Double = 0.6
+        var ROTATE_SPEED: Double = 0.3
 
         /** The speed at which the linear slide moves upwards. */
         @JvmField

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/RobotConfig.kt
@@ -97,6 +97,8 @@ object RobotConfig {
     /** Configuration related to moving using april tags. */
     @Config
     object AprilMovement {
+        // Multipliers against error values to proportionally control the speed of the robot.
+
         @JvmField
         var RANGE_GAIN: Double = 0.01
 
@@ -105,6 +107,8 @@ object RobotConfig {
 
         @JvmField
         var STRAFE_GAIN: Double = 0.005
+
+        // A threshold that the error must be below in order for the movement to finish.
 
         @JvmField
         var RANGE_ERROR: Double = 2.0
@@ -119,16 +123,33 @@ object RobotConfig {
     /** Configuration related to scanning april tags. */
     @Config
     object AprilVision {
+        /**
+         * Sets how many milliseconds of exposure should be used when scanning april tags.
+         *
+         * In general, a lower exposure is better for bright areas and higher exposure is better for
+         * darker areas. A higher exposure also increases motion blur, which is why in the
+         * configuration it is set to a low number.
+         *
+         * This will only be applied if `Vision.optimizeForAprilTags` is called.
+         */
         @JvmField
         var OPTIMUM_EXPOSURE: Long = 1
 
+        /**
+         * Sets the gain that should be used when scanning april tags.
+         *
+         * Gain is an offset used to artificially increase or decrease the brightness of an image.
+         *
+         * This will only be applied if `Vision.optimizeForAprilTags` is called.
+         */
         @JvmField
         var OPTIMUM_GAIN: Int = 255
     }
 
-    /** Configuration related to the main autonomous. */
+    /** Configuration related to the `AutoMain` opmode. */
     @Config
     object AutoMain {
+        /** A time in milliseconds that the robot waits before it starts moving in autonomous. */
         @JvmField
         var WAIT_TIME: Long = 0
     }
@@ -136,21 +157,26 @@ object RobotConfig {
     /** Configuration related to the TeleOpMovement component. */
     @Config
     object TeleOpMovement {
+        /** A multiplier that scales that robot's driving / strafing speed. */
         @JvmField
         var DRIVE_SPEED: Double = 0.6
 
+        /** A multiplier that scales the robot's rotation speed. */
         @JvmField
         var ROTATE_SPEED: Double = 0.5
 
+        /** A multiplier that scales the robot's rotation speed. */
         @JvmField
         var ROTATION_GAIN: Double = 0.6
 
         @JvmField
         var SLOW_MULTIPLIER: Double = 0.4
 
+        /** The speed at which the linear slide moves upwards. */
         @JvmField
         var SLIDE_UP_POWER: Double = 0.6
 
+        /** The speed at which the linear slide moves downwards. */
         @JvmField
         var SLIDE_DOWN_POWER: Double = -0.4
     }


### PR DESCRIPTION
This PR does a few things:

1. It adds documentation to all of the `RobotConfig` properties, so it is more clear what each things does.
2. Removes the `SLOW_MULTIPLIER` config ever since it was removed in #36.
3. Combines the `ROTATE_SPEED` and `ROTATION_GAIN` configs, since they literally both do the same thing.
4. Make `SLIDE_DOWN_POWER` a positive number instead of a negative one. (It's then negated in `TeleOpMain`. See 9bfa02d73a1e18b5bc1cb57a717ee35d89ec8aa3.)